### PR TITLE
🚨 Add Missing GitHub Skills Activity - Urgent Registration Fix

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Urgent: Add Missing GitHub Skills Activity

This PR addresses **Issue #6** - the missing GitHub Skills activity that was announced by the principal during the school assembly.

### Problem
Students were unable to find and register for the GitHub Skills activity despite the principal's announcement of a new partnership with GitHub. This was time-sensitive as registration closes by the end of this week.

### Solution
Added the "GitHub Skills" activity to the activities dictionary in `src/app.py` with:

- **Description**: Comprehensive description highlighting practical coding and collaboration skills through GitHub, including mention of the GitHub Certifications program for college applications
- **Schedule**: Mondays and Thursdays, 3:00 PM - 4:30 PM
- **Capacity**: 25 students (appropriate for a popular new program)
- **Status**: Ready for immediate student registration

### Impact
- ✅ Students can now find and register for the GitHub Skills activity
- ✅ Addresses the time-sensitive registration deadline
- ✅ Supports the school's new GitHub partnership initiative
- ✅ Helps students with college applications through GitHub Certifications

### Testing
The activity will appear in:
- The activities list on the main page
- The dropdown for student registration
- Available for immediate signup with 25 open spots

Fixes #6

---
*Generated via GitHub Copilot with MCP integration* 🤖